### PR TITLE
Add a remote toggle for telemetry

### DIFF
--- a/src/tabpfn_common_utils/main.py
+++ b/src/tabpfn_common_utils/main.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Example usage of TabPFN telemetry events."""
+
+import numpy as np
+
+from tabpfn_common_utils.telemetry import (
+    PingEvent,
+    FitEvent,
+    PredictEvent,
+    capture_event,
+)
+
+
+def main():
+    """Example of sending various telemetry events."""
+    print("🔗 Sending TabPFN telemetry events...")
+
+    # 1. Send a ping event (user activity tracking)
+    print("\n1. Sending ping event...")
+    ping_event = PingEvent()
+    capture_event(ping_event)
+    print(f"   Sent ping event: {ping_event.name}")
+
+    # 2. Send a fit event (model training)
+    print("\n3. Sending fit event...")
+    fit_event = FitEvent(
+        task="classification",
+        num_rows=120,
+        num_columns=4,
+        duration_ms=1250
+    )
+    capture_event(fit_event)
+    print(f"   Sent fit event: {fit_event.name}")
+
+    # 3. Send a predict event (model prediction)
+    print("\n4. Sending predict event...")
+    predict_event = PredictEvent(
+        task="classification",
+        num_rows=30,
+        num_columns=4,
+        duration_ms=180
+    )
+    capture_event(predict_event)
+    print(f"   Sent predict event: {predict_event.name}")
+
+    # 5. Example with real data shapes
+    print("\n5. Sending events with real data...")
+    
+    # Create sample data
+    X_train = np.random.rand(100, 5)
+    y_train = np.random.randint(0, 3, 100)
+    X_test = np.random.rand(25, 5)
+    
+    # Fit event with actual training data
+    fit_event_real = FitEvent(
+        task="classification",
+        num_rows=X_train.shape[0],
+        num_columns=X_train.shape[1],
+        duration_ms=2100
+    )
+    capture_event(fit_event_real)
+    print(f"   Sent fit event with training data: {X_train.shape}")
+
+    # Predict event with test data
+    predict_event_real = PredictEvent(
+        task="classification",
+        num_rows=X_test.shape[0],
+        num_columns=X_test.shape[1],
+        duration_ms=350
+    )
+    capture_event(predict_event_real)
+    print(f"   Sent predict event with test data: {X_test.shape}")
+
+    print("\n✅ All telemetry events sent successfully!")
+    print("\nNote: Events are sent to PostHog anonymously.")
+    print("To disable telemetry, set: TABPFN_DISABLE_TELEMETRY=1")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tabpfn_common_utils/telemetry/core/service.py
+++ b/src/tabpfn_common_utils/telemetry/core/service.py
@@ -1,11 +1,17 @@
+import logging
 import os
+import requests
 
 from datetime import datetime
 from posthog import Posthog
 from .events import BaseTelemetryEvent
 from .runtime import get_runtime
-from ...utils import singleton
+from ...utils import singleton, ttl_cache
 from typing import Any, Dict, Optional
+
+
+# Set up logging
+logger = logging.getLogger(__name__)
 
 
 @singleton
@@ -42,8 +48,8 @@ class ProductTelemetry:
             flush_at=flush_at,
         )
 
-    @staticmethod
-    def telemetry_enabled() -> bool:
+    @classmethod
+    def telemetry_enabled(cls) -> bool:
         """
         Check if telemetry is enabled.
 
@@ -53,7 +59,36 @@ class ProductTelemetry:
         # Disable telemetry by default in CI environments, but allow override
         runtime = get_runtime()
         default_disable = "1" if runtime.ci else "0"
-        return os.getenv("TABPFN_DISABLE_TELEMETRY", default_disable).lower() not in ("1", "true")
+
+        # Overwrite any settings based on server-side configuration
+        config = cls._download_config()
+        if config["enabled"] is False:
+            return False
+
+        value = os.getenv("TABPFN_DISABLE_TELEMETRY", default_disable).lower()
+        return value not in ("1", "true")
+
+    @classmethod
+    @ttl_cache(ttl_seconds=60 * 5)
+    def _download_config(cls) -> Dict[str, Any]:
+        """Download the configuration from server.
+
+        Returns:
+            Dict[str, Any]: The configuration.
+        """
+        # This is a public URL anyone can and should read from
+        url = os.environ.get(
+            "TABPFN_TELEMETRY_CONFIG_URL",
+            "https://storage.googleapis.com/prior-labs-tabpfn-public/config/telemetry.json",
+        )
+        resp = requests.get(url)
+
+        # Disable telemetry by default
+        if resp.status_code != 200:
+            logger.debug(f"Failed to download telemetry config: {resp.status_code}")
+            return {"enabled": False}
+
+        return resp.json()
 
     def capture(
         self,
@@ -72,7 +107,7 @@ class ProductTelemetry:
             properties (dict): The additional properties attached to an event.
             timestamp (datetime): The timestamp of the event.
         """
-        if self._posthog_client is None:
+        if self._do_flush_or_capture() is False:
             return
 
         # Anonymous default UUID in case no explicit consent to opt in to telemetry
@@ -82,7 +117,8 @@ class ProductTelemetry:
         properties = {**event.properties, **(properties or {})}
 
         try:
-            self._posthog_client.capture(
+            # self._posthog_client will not be None if self._do_flush_or_capture() is True
+            self._posthog_client.capture(  # type: ignore
                 distinct_id=user_id,
                 event=event.name,
                 properties=properties,
@@ -96,7 +132,7 @@ class ProductTelemetry:
         """
         Flush the PostHog client telemetry queue.
         """
-        if not self._posthog_client:
+        if self._do_flush_or_capture() is False:
             return
 
         try:
@@ -104,6 +140,14 @@ class ProductTelemetry:
         except Exception:
             # Silently ignore any errors
             pass
+
+    def _do_flush_or_capture(self) -> bool:
+        """Determine whether to handle a capture or flush event.
+
+        Returns:
+            bool: True if the event should be handled, False otherwise.
+        """
+        return self.telemetry_enabled() is True and self._posthog_client is not None
 
 
 def capture_event(


### PR DESCRIPTION
### Context

We need to be able to switch any telemetry **on** or **off** without having to release or yank a PyPI release. 

We have a remote configuration file that telemetry downloads (and cached, 2B in size). This file is located in a **private** GCP bucket and made publicly available (**only read** permissions).

