### PR TITLE
[ENG-187] Change behaviour for `opt_in`

### DIFF
--- a/src/tabpfn_common_utils/telemetry/core/config.py
+++ b/src/tabpfn_common_utils/telemetry/core/config.py
@@ -1,0 +1,54 @@
+"""
+Configuration utilities for telemetry system.
+
+This module provides functionality to download and cache telemetry configuration
+from a remote server.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import requests
+from tabpfn_common_utils.utils import ttl_cache
+
+
+logger = logging.getLogger(__name__)
+
+
+@ttl_cache(ttl_seconds=60 * 5)
+def download_config() -> Dict[str, Any]:
+    """Download the configuration from server.
+
+    Returns:
+        Dict[str, Any]: The configuration.
+    """
+    # Bust the cache
+    params = {
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+    # The default configuration
+    default = {"enabled": False}
+
+    # This is a public URL anyone can and should read from
+    url = os.environ.get(
+        "TABPFN_TELEMETRY_CONFIG_URL",
+        "https://storage.googleapis.com/prior-labs-tabpfn-public/config/telemetry.json",
+    )
+    try:
+        resp = requests.get(url, params=params)
+    except Exception:
+        logger.debug(f"Failed to download telemetry config: {url}")
+        return default
+
+    # Disable telemetry by default
+    if resp.status_code != 200:
+        logger.debug(f"Failed to download telemetry config: {resp.status_code}")
+        return default
+
+    return resp.json()

--- a/src/tabpfn_common_utils/telemetry/interactive/flows.py
+++ b/src/tabpfn_common_utils/telemetry/interactive/flows.py
@@ -64,6 +64,24 @@ def _trigger_prompts(delta_days: int, max_prompts: int) -> bool:
     """
     utc_now = datetime.now(timezone.utc)
 
+    # If new installation, don't prompt
+    install_date = get_property("install_date", data_type=datetime)
+    if not install_date:
+        set_property("install_date", utc_now)
+        return False
+
+    # Avoid prompt in first 24 hours
+    if utc_now - install_date <= timedelta(hours=24):
+        return False
+
+    # If used <= 5 times, don't prompt
+    nr_usages = get_property("nr_usages", 0, data_type=int)
+    set_property("nr_usages", nr_usages + 1)
+
+    if nr_usages <= 5:
+        return False
+
+    # If last prompted > 30 days, prompt
     last_prompted_at = get_property("last_prompted_at", data_type=datetime)
     if not last_prompted_at:
         return True

--- a/src/tabpfn_common_utils/telemetry/interactive/flows.py
+++ b/src/tabpfn_common_utils/telemetry/interactive/flows.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 from typing import List
+from ..core.config import download_config
 from ..core.state import get_property, set_property
 from ..core import PingEvent, capture_event
 from .prompts.base import PromptSpec
@@ -64,6 +65,13 @@ def _trigger_prompts(delta_days: int, max_prompts: int) -> bool:
     """
     utc_now = datetime.now(timezone.utc)
 
+    # Download prompt configuration
+    config = download_config()
+
+    # By default, don't prompt
+    if not config.get("prompt_user", False):
+        return False
+
     # If new installation, don't prompt
     install_date = get_property("install_date", data_type=datetime)
     if not install_date:
@@ -71,14 +79,15 @@ def _trigger_prompts(delta_days: int, max_prompts: int) -> bool:
         return False
 
     # Avoid prompt in first 24 hours
-    if utc_now - install_date <= timedelta(hours=24):
+    delta_hours = config.get("prompt_delta_hours", 24)
+    if utc_now - install_date <= timedelta(hours=delta_hours):
         return False
 
     # If used <= 5 times, don't prompt
     nr_usages = get_property("nr_usages", 0, data_type=int)
     set_property("nr_usages", nr_usages + 1)
 
-    if nr_usages <= 5:
+    if nr_usages < config.get("prompt_nr_usages", 5):
         return False
 
     # If last prompted > 30 days, prompt


### PR DESCRIPTION
### Change Description

- Don't prompt for `opt_in` under 24 hours since install
- Don't prompt if number of usages below 5
- Refactored `ProductTelemetry` and moved `download_config` to `telemetry/config.py` to make it more easily accessible to other functions.