### PR TITLE
add license info to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ readme = "README.md"
 authors = [
     {name = "Prior Labs", email = "hello@priorlabs.ai"}
 ]
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 maintainers = [
     {name = "Prior Labs", email = "hello@priorlabs.ai"}
 ]


### PR DESCRIPTION
### Change Description

Add license info to pyproject.toml so that it is included in the package metadata.