### PR TITLE
Package metadata + README hygiene

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "tabpfn-common-utils"
 dynamic = ["version"]
 description = "Utilities shared between TabPFN codebases"
 readme = "README.md"
+license = { file = "LICENSE" }
 authors = [
     {name = "Prior Labs", email = "hello@priorlabs.ai"}
 ]


### PR DESCRIPTION
## Summary

Two small metadata/cleanup changes:

1. **Declare license in `pyproject.toml`.** Add `license = { file = "LICENSE" }` to the `[project]` table so PyPI and license scanners pick up the existing Apache-2.0 LICENSE file. Without this, the package shows as `license: UNKNOWN` on PyPI even though the LICENSE file is present in the source tree. Picks up automatically on the next tagged release.

2. **README cleanup.** Trim the "comprehensive utility package" tagline to a factual one-liner; drop emoji icons from section headers; reorder Features so data-processing utilities come first and telemetry isn't the headline (it's optional and opt-out); replace the bullet-list "Privacy & Compliance" section with a shorter Telemetry notes block.

The GitHub repo description has also been set to match the new tagline.

No code or runtime change.

## Test plan
- [x] `pyproject.toml` parses (one new key)
- [x] No remaining emoji characters in README
- [ ] After next tag: confirm `pip show tabpfn-common-utils` reports the license
- [ ] After next tag: confirm PyPI page shows Apache-2.0 instead of UNKNOWN

🤖 Generated with [Claude Code](https://claude.com/claude-code)