### PR TITLE
chore: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,12 @@
 # Security
 
+## Supported Versions
+
+We support only the most recent minor release. Older releases do not
+receive security patches — please upgrade.
+
+## Reporting a Vulnerability
+
 Please email **security@priorlabs.ai** to report a vulnerability.
 
 We support coordinated disclosure and will acknowledge promptly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security
+
+Please email **security@priorlabs.ai** to report a vulnerability.
+
+We support coordinated disclosure and will acknowledge promptly.
+Don't file public GitHub issues for suspected vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ receive security patches — please upgrade.
 Please email **security@priorlabs.ai** to report a vulnerability.
 
 We support coordinated disclosure and will acknowledge promptly.
-Don't file public GitHub issues for suspected vulnerabilities.
+Please do not report security vulnerabilities via public GitHub issues.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` pointing reports to `security@priorlabs.ai`. GitHub auto-renders this as the "Report a vulnerability" link on the repo's Security tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)