### PR TITLE
Remove hardcoded Posthog project token (even though it's meant to be public)

### DIFF
--- a/src/tabpfn_common_utils/telemetry/core/service.py
+++ b/src/tabpfn_common_utils/telemetry/core/service.py
@@ -28,7 +28,7 @@ class ProductTelemetry:
 
     # PostHog project ingestion token, read from the environment so no
     # credential ships in the package. When unset, telemetry is a no-op.
-    PROJECT_TOKEN: Optional[str] = os.getenv("TABPFN_POSTHOG_PROJECT_TOKEN")
+    PROJECT_API_KEY: Optional[str] = os.getenv("TABPFN_POSTHOG_PROJECT_TOKEN")
 
     # Public PostHog host (EU)
     HOST = "https://eu.i.posthog.com"
@@ -51,7 +51,7 @@ class ProductTelemetry:
             return
 
         if api_key is None:
-            api_key = self.PROJECT_TOKEN
+            api_key = self.PROJECT_API_KEY
 
         # No token → we cannot emit telemetry; remain a no-op.
         if not api_key:

--- a/src/tabpfn_common_utils/telemetry/core/service.py
+++ b/src/tabpfn_common_utils/telemetry/core/service.py
@@ -28,7 +28,7 @@ class ProductTelemetry:
 
     # PostHog project ingestion token, read from the environment so no
     # credential ships in the package. When unset, telemetry is a no-op.
-    PROJECT_API_KEY: Optional[str] = os.getenv("TABPFN_POSTHOG_PROJECT_TOKEN")
+    PROJECT_TOKEN: Optional[str] = os.getenv("TABPFN_POSTHOG_PROJECT_TOKEN")
 
     # Public PostHog host (EU)
     HOST = "https://eu.i.posthog.com"
@@ -51,9 +51,9 @@ class ProductTelemetry:
             return
 
         if api_key is None:
-            api_key = self.PROJECT_API_KEY
+            api_key = self.PROJECT_TOKEN
 
-        # No key → we cannot emit telemetry; remain a no-op.
+        # No token → we cannot emit telemetry; remain a no-op.
         if not api_key:
             self._posthog_client = None
             return

--- a/src/tabpfn_common_utils/telemetry/core/service.py
+++ b/src/tabpfn_common_utils/telemetry/core/service.py
@@ -26,8 +26,9 @@ class ProductTelemetry:
     Service for capturing anonymous and aggregated telemetry data.
     """
 
-    # Public PostHog project API key
-    PROJECT_API_KEY = "phc_wemJSoR4e8rGJomHz0clm6aHdOWp0EvpRP368uVsUvJ"
+    # PostHog project ingestion token, read from the environment so no
+    # credential ships in the package. When unset, telemetry is a no-op.
+    PROJECT_API_KEY: Optional[str] = os.getenv("TABPFN_POSTHOG_PROJECT_TOKEN")
 
     # Public PostHog host (EU)
     HOST = "https://eu.i.posthog.com"
@@ -51,6 +52,11 @@ class ProductTelemetry:
 
         if api_key is None:
             api_key = self.PROJECT_API_KEY
+
+        # No key → we cannot emit telemetry; remain a no-op.
+        if not api_key:
+            self._posthog_client = None
+            return
 
         # Initialize the PostHog client
         self._posthog_client = Posthog(
@@ -138,8 +144,12 @@ class ProductTelemetry:
         if self.telemetry_enabled() is False:
             return
 
+        # Add the check just for type safety
+        if self._posthog_client is None:
+            return
+
         try:
-            self._posthog_client.flush()  # type: ignore
+            self._posthog_client.flush()
         except Exception:
             # Silently ignore any errors
             pass

--- a/src/tabpfn_common_utils/telemetry/core/service.py
+++ b/src/tabpfn_common_utils/telemetry/core/service.py
@@ -28,7 +28,7 @@ class ProductTelemetry:
 
     # PostHog project ingestion token, read from the environment so no
     # credential ships in the package. When unset, telemetry is a no-op.
-    PROJECT_API_KEY: Optional[str] = os.getenv("TABPFN_POSTHOG_PROJECT_TOKEN")
+    PROJECT_API_KEY: Optional[str] = os.getenv("PRIOR_POSTHOG_PROJECT_TOKEN")
 
     # Public PostHog host (EU)
     HOST = "https://eu.i.posthog.com"


### PR DESCRIPTION
To remove all doubt that this token is misplaced, and given that we don't collect analytics in OSS anyway, replace a hardcoded token with an environment variable. 